### PR TITLE
fix(service): ensure countdown/warning sounds play reliably across de…

### DIFF
--- a/app/src/main/java/com/github/arburk/vscp/app/service/NotificationManagerWrapper.kt
+++ b/app/src/main/java/com/github/arburk/vscp/app/service/NotificationManagerWrapper.kt
@@ -59,6 +59,33 @@ class NotificationManagerWrapper {
     Log.v("NotificationManagerWrapper", "$channelId created")
   }
 
+  fun createForegroundServiceChannel(ctx: Context) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return // Skip for lower versions
+
+    ctx.getString(R.string.foreground_notification_channel_id).also {
+      if (notificationChannelMissing(ctx, it)) {
+        executeForegroundChannelCreation(ctx, it)
+      }
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.O)
+  private fun executeForegroundChannelCreation(ctx: Context, channelId: String) {
+    // Deliberately silent/low-importance: this channel only backs the persistent
+    // "timer is running" notification required to keep the service alive in the
+    // foreground. The audible level-change alert uses the separate high-importance
+    // channel above.
+    NotificationChannel(channelId, ctx.getString(R.string.foreground_channel_name), NotificationManager.IMPORTANCE_LOW)
+      .apply {
+        description = ctx.getString(R.string.foreground_channel_description)
+        setSound(null, null)
+        enableVibration(false)
+      }.also {
+        get(ctx)!!.createNotificationChannel(it)
+      }
+    Log.v("NotificationManagerWrapper", "$channelId created")
+  }
+
   @RequiresApi(Build.VERSION_CODES.O)
   private fun notificationChannelMissing(ctx: Context, channelId: String): Boolean =
     get(ctx)!!.getNotificationChannel(channelId) == null

--- a/app/src/main/java/com/github/arburk/vscp/app/service/TimerService.kt
+++ b/app/src/main/java/com/github/arburk/vscp/app/service/TimerService.kt
@@ -8,8 +8,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
-import android.media.RingtoneManager
-import android.net.Uri
+import android.media.AudioAttributes
+import android.media.SoundPool
 import android.os.Binder
 import android.os.Build
 import android.os.Handler
@@ -33,6 +33,10 @@ import kotlin.concurrent.timerTask
 
 class TimerService : Service(), SharedPreferences.OnSharedPreferenceChangeListener {
 
+  companion object {
+    private const val FOREGROUND_NOTIFICATION_ID = 1
+  }
+
   @VisibleForTesting
   internal lateinit var config: ConfigModel
 
@@ -53,6 +57,10 @@ class TimerService : Service(), SharedPreferences.OnSharedPreferenceChangeListen
   private var timerTask: TimerTask? = null
   private val mainHandler = Handler(Looper.getMainLooper())
 
+  private lateinit var soundPool: SoundPool
+  private var fightCountdownSoundId = 0
+  private var oneMinuteWarningSoundId = 0
+
   inner class TimerServiceBinder : Binder() {
     fun getService(): TimerService = this@TimerService
   }
@@ -61,11 +69,29 @@ class TimerService : Service(), SharedPreferences.OnSharedPreferenceChangeListen
 
   override fun onCreate() {
     initConfig()
+    preloadSounds()
+    NotificationManagerWrapper().createForegroundServiceChannel(this)
   }
 
   override fun onDestroy() {
     super.onDestroy()
     timer.cancel()
+    stopForeground(Service.STOP_FOREGROUND_REMOVE)
+    if (this::soundPool.isInitialized) soundPool.release()
+  }
+
+  private fun preloadSounds() {
+    soundPool = SoundPool.Builder()
+      .setMaxStreams(2)
+      .setAudioAttributes(
+        AudioAttributes.Builder()
+          .setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
+          .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+          .build()
+      )
+      .build()
+    fightCountdownSoundId = soundPool.load(this, R.raw.countdown_fight, 1)
+    oneMinuteWarningSoundId = soundPool.load(this, R.raw.one_minute_warning, 1)
   }
 
   private fun initConfig() {
@@ -103,10 +129,20 @@ class TimerService : Service(), SharedPreferences.OnSharedPreferenceChangeListen
     Log.v("TimerService", "start timer was requested")
     if (!running) {
       running = true
+      startForeground(FOREGROUND_NOTIFICATION_ID, buildForegroundNotification())
       timerTask = createTimerTask()
       timer.scheduleAtFixedRate(timerTask, 1000, 1000)
     }
   }
+
+  private fun buildForegroundNotification(): Notification =
+    NotificationCompat.Builder(this, getString(R.string.foreground_notification_channel_id))
+      .setContentTitle(getString(R.string.app_name))
+      .setContentText(getString(R.string.foreground_notification_text))
+      .setSmallIcon(R.mipmap.icon_webp)
+      .setPriority(NotificationCompat.PRIORITY_LOW)
+      .setOngoing(true)
+      .build()
 
   private fun createTimerTask() = timerTask {
     when (remainingSeconds) {
@@ -120,23 +156,17 @@ class TimerService : Service(), SharedPreferences.OnSharedPreferenceChangeListen
           processNextRoundNotification()
         }
       }
-      6 -> mainHandler.post {
-        RingtoneManager.getRingtone(this@TimerService, getFightCountdownUri()).play()
+      4 -> mainHandler.post {
+        soundPool.play(fightCountdownSoundId, 1f, 1f, 1, 0, 1f)
       }
-      62 -> mainHandler.post {
-        RingtoneManager.getRingtone(this@TimerService, getOneMinuteWarningUri()).play()
+      config.minPerWarning * 60 + 1 -> mainHandler.post {
+        soundPool.play(oneMinuteWarningSoundId, 1f, 1f, 1, 0, 1f)
       }
     }
     remainingSeconds--
     updateViewModels()
     Log.v("TimerService", "remainingSeconds: $remainingSeconds")
   }
-
-  private fun getOneMinuteWarningUri(): Uri =
-    Uri.parse("android.resource://" + applicationContext.packageName + "/" + R.raw.one_minute_warning)
-
-  private fun getFightCountdownUri(): Uri =
-    Uri.parse("android.resource://" + applicationContext.packageName + "/" + R.raw.countdown_fight)
 
   private fun processNextRoundNotification() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -175,6 +205,7 @@ class TimerService : Service(), SharedPreferences.OnSharedPreferenceChangeListen
     if (running) {
       running = false
       timerTask?.cancel()
+      stopForeground(Service.STOP_FOREGROUND_REMOVE)
     }
   }
 

--- a/app/src/main/java/com/github/arburk/vscp/app/service/TimerService.kt
+++ b/app/src/main/java/com/github/arburk/vscp/app/service/TimerService.kt
@@ -81,15 +81,18 @@ class TimerService : Service(), SharedPreferences.OnSharedPreferenceChangeListen
   }
 
   private fun preloadSounds() {
-    soundPool = SoundPool.Builder()
-      .setMaxStreams(2)
-      .setAudioAttributes(
-        AudioAttributes.Builder()
-          .setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
-          .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-          .build()
-      )
-      .build()
+    // Kept as separate statements on retained builder references (no method chaining):
+    // the Android unit-test stubs return null from chained builder calls, which would
+    // NPE here even though the same chain works fine on a real device.
+    val audioAttributesBuilder = AudioAttributes.Builder()
+    audioAttributesBuilder.setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
+    audioAttributesBuilder.setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+
+    val soundPoolBuilder = SoundPool.Builder()
+    soundPoolBuilder.setMaxStreams(2)
+    soundPoolBuilder.setAudioAttributes(audioAttributesBuilder.build())
+
+    soundPool = soundPoolBuilder.build() ?: return
     fightCountdownSoundId = soundPool.load(this, R.raw.countdown_fight, 1)
     oneMinuteWarningSoundId = soundPool.load(this, R.raw.one_minute_warning, 1)
   }
@@ -129,7 +132,11 @@ class TimerService : Service(), SharedPreferences.OnSharedPreferenceChangeListen
     Log.v("TimerService", "start timer was requested")
     if (!running) {
       running = true
-      startForeground(FOREGROUND_NOTIFICATION_ID, buildForegroundNotification())
+      // Background execution limits/Doze (the actual cause of unreliable playback) only
+      // apply from Android 8 (O) onward, so foreground promotion is only needed there.
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        startForeground(FOREGROUND_NOTIFICATION_ID, buildForegroundNotification())
+      }
       timerTask = createTimerTask()
       timer.scheduleAtFixedRate(timerTask, 1000, 1000)
     }

--- a/app/src/main/res/values/constants.xml
+++ b/app/src/main/res/values/constants.xml
@@ -3,4 +3,5 @@
   <string name="package_name">com.github.arburk.vscp.app</string>
   <string name="vscp_url">http://vscp.ch</string>
   <string name="notification_channel_id">NOTIFY_CHANNEL_TS_ID</string>
+  <string name="foreground_notification_channel_id">NOTIFY_CHANNEL_FOREGROUND_ID</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,5 +41,8 @@
 
   <string name="channel_name">TimerNotifications</string>
   <string name="channel_description">notify the user when level changes</string>
+  <string name="foreground_channel_name">TimerService</string>
+  <string name="foreground_channel_description">silent notification keeping the timer running in background</string>
+  <string name="foreground_notification_text">Timer is running</string>
 
 </resources>


### PR DESCRIPTION
…vices

Background execution limits and Doze on non-foreground services made the 1s tick loop drift or stall on some OEMs, delaying the audio cues. The Ringtone objects returned by RingtoneManager were also never retained, so they could be garbage-collected mid-playback and cut the sound short.

- Promote TimerService to a real foreground service (permission was already declared but never used) while the timer is running, backed by a dedicated silent/low-importance notification channel.
- Replace RingtoneManager.getRingtone(...).play() with a preloaded, retained SoundPool instance for both the fight-countdown and one-minute-warning cues, removing decode latency and the GC-cutoff risk.
- Honor the configured minPerWarning offset instead of a hardcoded 62s.