### PR TITLE
build(release): add signed release build and tag-triggered release wo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+# Runs only on tags of the own repository - secrets are never exposed to fork PRs.
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version without leading v, e.g. 0.9.0 (creates tag v<version>)'
+        required: true
+        type: string
+
+permissions:
+  contents: write # required to create the release and push its tag
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Instrumented tests are covered by connected_check_on_pr.yml on main; a tag always
+      # points at an already tested commit, so the release skips the ~30 min emulator run.
+      - name: Quality gate
+        run: ./gradlew clean build lint
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+
+      - name: Assemble signed release
+        env:
+          KEYSTORE_FILE: ${{ runner.temp }}/release.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ./gradlew assembleRelease -PversionName="$VERSION"
+          mv app/build/outputs/apk/release/app-release.apk "vscp-pokertimer-${VERSION}.apk"
+          sha256sum vscp-pokertimer-*.apk > SHA256SUMS.txt
+
+      - name: Verify signature
+        run: |
+          # Pick the newest installed build-tools instead of pinning a version that may
+          # disappear from the runner image.
+          BUILD_TOOLS="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n1)"
+          "$ANDROID_HOME/build-tools/$BUILD_TOOLS/apksigner" verify --print-certs \
+            vscp-pokertimer-*.apk
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true # reviewed manually, then published
+          tag_name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
+          files: |
+            vscp-pokertimer-*.apk
+            SHA256SUMS.txt
+
+      - name: Cleanup keystore
+        if: always()
+        run: rm -f "$RUNNER_TEMP/release.jks"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .cxx
 local.properties
 /Github.http
+*.jks
+*.keystore

--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ Pokertimer and sit'n'go tournament as native Android app to learn this technolog
 Project was launched in order to learn more about native Android application development using kotlin.
 
 
+## Installation
+
+The app is not published in the Play Store. Signed APKs are attached to every
+[GitHub Release](https://github.com/arburk/vscp/releases) and installed by sideloading.
+
+Requirement: Android 7.1 (API 25) or newer.
+
+1. Open the [latest release](https://github.com/arburk/vscp/releases/latest) and download
+   `vscp-pokertimer-<version>.apk`.
+2. Open the downloaded file. Android asks to allow "Install unknown apps" for the app you
+   downloaded with (browser or file manager) - the permission is granted per source app
+   since Android 8.
+3. Optional integrity check against `SHA256SUMS.txt` from the same release:
+   ```bash
+   sha256sum -c SHA256SUMS.txt
+   ```
+4. Play Protect may warn on first start because the app does not come from the store.
+
+Updates install straight over the existing app - same signing key, higher version code.
+To get notified about new releases without a store, subscribe to the repository with
+[Obtainium](https://github.com/ImranR98/Obtainium).
+
 ## Settings
 ### Common
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,24 @@ plugins {
   id("de.mannodermaus.android-junit5") version "2.0.1"
 }
 
+// The git tag is the single source of truth for the version: the release workflow passes
+// -PversionName=<tag without the leading v>. Local builds fall back to a snapshot version.
+def appVersionName = providers.gradleProperty('versionName').getOrElse('0.0.1-SNAPSHOT')
+
+// Strictly monotonic and derived from the version name: 1.2.0 -> 1002000. Pre-release
+// suffixes are cut off, so v1.2.0-rc1 and v1.2.0 share the same code - publish only one.
+static int versionCodeOf(String name) {
+  def parts = name.replaceAll('-.*$', '').tokenize('.')
+  if (parts.size() != 3) {
+    throw new GradleException("versionName '$name' is not MAJOR.MINOR.PATCH[-qualifier]")
+  }
+  parts[0].toInteger() * 1_000_000 + parts[1].toInteger() * 1_000 + parts[2].toInteger()
+}
+
+// Set by the release workflow after it has decoded the keystore secret. Without it the
+// release build stays unsigned instead of failing, so local builds work without secrets.
+def keystorePath = System.getenv('KEYSTORE_FILE')
+
 android {
   namespace = 'com.github.arburk.vscp.app'
   compileSdk 37
@@ -13,8 +31,8 @@ android {
     applicationId "com.github.arburk.vscp.app"
     minSdk 25
     targetSdk 35
-    versionCode 1
-    versionName "1.0"
+    versionCode versionCodeOf(appVersionName)
+    versionName appVersionName
 
     // Make sure to use the AndroidJUnitRunner (or a sub-class) in order to hook in the JUnit 5 Test Builder
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -22,11 +40,26 @@ android {
     testInstrumentationRunnerArguments["configurationParameters"] = "junit.jupiter.execution.parallel.enabled=true,junit.jupiter.execution.parallel.mode.default=concurrent"
   }
 
+  signingConfigs {
+    release {
+      if (keystorePath) {
+        storeFile file(keystorePath)
+        storePassword System.getenv('KEYSTORE_PASSWORD')
+        keyAlias System.getenv('KEY_ALIAS')
+        keyPassword System.getenv('KEY_PASSWORD')
+      }
+    }
+  }
+
   buildTypes {
     release {
       minifyEnabled false
       debuggable false
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+      // Wired conditionally: an empty signingConfig fails validateSigningRelease.
+      if (keystorePath) {
+        signingConfig signingConfigs.release
+      }
     }
     debug {
       debuggable true


### PR DESCRIPTION
…rkflow

Derive versionName/versionCode from -PversionName (git tag) with a snapshot fallback for local builds, wire a release signingConfig fed from environment variables, and add .github/workflows/release.yml that builds, signs and verifies the APK and publishes it as a draft GitHub Release with checksums.

Refs #17